### PR TITLE
refactor: typescript react dont import babel [no issue]

### DIFF
--- a/@ornikar/eslint-config-babel/README.md
+++ b/@ornikar/eslint-config-babel/README.md
@@ -7,7 +7,6 @@ Based on Airbnb.
 Also see:
 
 - [@ornikar/eslint-config](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config)
-- [@ornikar/eslint-config-node](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-node)
 - [@ornikar/eslint-config-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-react)
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript-react)

--- a/@ornikar/eslint-config-react/README.md
+++ b/@ornikar/eslint-config-react/README.md
@@ -8,16 +8,15 @@ Also see:
 
 - [@ornikar/eslint-config](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config)
 - [@ornikar/eslint-config-babel](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-babel)
-- [@ornikar/eslint-config-node](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-node)
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript-react)
 
 ### react
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-react`
-2. Add `"extends": ["@ornikar/eslint-config-react"]` to your eslint config
+1. `npm install --save-dev eslint @ornikar/eslint-config-babel @ornikar/eslint-config-react`
+2. Add `"extends": ["@ornikar/eslint-config-babel", "@ornikar/eslint-config-react"]` to your eslint config
 
 ### react-native
 
 1. `npm install --save-dev eslint @ornikar/eslint-config-react`
-2. Add `"extends": ["@ornikar/eslint-config-react/react-native"]` to your eslint config
+2. Add `"extends": ["@ornikar/eslint-config-babel", "@ornikar/eslint-config-react/react-native"]` to your eslint config

--- a/@ornikar/eslint-config-react/index.js
+++ b/@ornikar/eslint-config-react/index.js
@@ -2,10 +2,8 @@
 
 module.exports = {
   extends: [
-    '@ornikar/eslint-config-babel',
     'eslint-config-airbnb/rules/react',
     'eslint-config-airbnb/rules/react-a11y',
-    'eslint-config-prettier',
     'eslint-config-prettier/react',
     './rules/react',
   ].map(require.resolve),

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -12,7 +12,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config-babel": "^12.3.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-react": "^7.20.3",

--- a/@ornikar/eslint-config-react/tests/.eslintrc.json
+++ b/@ornikar/eslint-config-react/tests/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["../../eslint-config/index.js", "../index.js"],
+  "extends": ["../../eslint-config-babel/index.js", "../index.js"],
   "rules": {
     "import/no-extraneous-dependencies": "off"
   }

--- a/@ornikar/eslint-config-typescript-react/README.md
+++ b/@ornikar/eslint-config-typescript-react/README.md
@@ -8,9 +8,8 @@ Also see:
 
 - [@ornikar/eslint-config](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config)
 - [@ornikar/eslint-config-babel](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-babel)
-- [@ornikar/eslint-config-node](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-node)
 - [@ornikar/eslint-config-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-react)
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript)
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-typescript`
-2. Add `"extends": "@ornikar/eslint-config-typescript-react"` to your eslint config
+1. `npm install --save-dev eslint @ornikar/eslint-config-typescript @ornikar/eslint-config-typescript-react`
+2. Add `"extends": ["@ornikar/eslint-config-typescript", "@ornikar/eslint-config-typescript-react"]` to your eslint config

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ornikar/eslint-config-typescript": "^12.3.0",
     "@ornikar/eslint-config-react": "^12.3.0",
     "eslint-config-prettier": "^6.7.0"
   },

--- a/@ornikar/eslint-config-typescript-react/react-native.js
+++ b/@ornikar/eslint-config-typescript-react/react-native.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   extends: [
-    '@ornikar/eslint-config-react',
+    '@ornikar/eslint-config-react/react-native',
     // overrides for react with typescript (mostly extensions)
     './rules/import',
     './rules/react',
@@ -11,7 +11,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.ts', '.tsx'],
+        extensions: ['.js', '.ts', '.tsx', '.ios.ts', '.android.ts', '.ios.tsx', '.android.tsx'],
       },
     },
   },

--- a/@ornikar/eslint-config-typescript-react/rules/import.js
+++ b/@ornikar/eslint-config-typescript-react/rules/import.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
+  },
+};

--- a/@ornikar/eslint-config-typescript-react/rules/react.js
+++ b/@ornikar/eslint-config-typescript-react/rules/react.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'react/jsx-filename-extension': [
+      'error',
+      {
+        extensions: ['tsx'],
+      },
+    ],
+    'react/prop-types': 'off',
+  },
+};

--- a/@ornikar/eslint-config-typescript/README.md
+++ b/@ornikar/eslint-config-typescript/README.md
@@ -8,7 +8,6 @@ Also see:
 
 - [@ornikar/eslint-config](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config)
 - [@ornikar/eslint-config-babel](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-babel)
-- [@ornikar/eslint-config-node](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-node)
 - [@ornikar/eslint-config-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-react)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/eslint-configs/tree/master/%40ornikar/eslint-config-typescript-react)
 


### PR DESCRIPTION
BREAKING CHANGE: extending eslint-config-react will also require to extends eslint-config-babel

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
