### PR TITLE
feat(eslint-config): add config for rollup ARCH-826

### DIFF
--- a/@ornikar/eslint-config/rollup.js
+++ b/@ornikar/eslint-config/rollup.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// See https://github.com/ornikar/shared-configs/tree/master/%40ornikar/rollup-config
+module.exports = {
+  globals: {
+    __DEV__: true,
+    __TARGET__: true,
+  },
+};


### PR DESCRIPTION
### Context

We cannot place it in `@ornikar/rollup-config`, eslint expects it under `@scope/eslint-config(-*)?`

https://github.com/ornikar/shared-configs/pull/457

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
