### PR TITLE
fix: move import/extensions rule in eslint-config [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/index.js
+++ b/@ornikar/eslint-config-react/index.js
@@ -19,13 +19,6 @@ module.exports = {
   },
 
   rules: {
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      {
-        js: 'never',
-      },
-    ],
     'react/jsx-filename-extension': ['error', { extensions: ['js'] }],
 
     'react-hooks/rules-of-hooks': 'error',

--- a/@ornikar/eslint-config/index.js
+++ b/@ornikar/eslint-config/index.js
@@ -18,5 +18,12 @@ module.exports = {
 
   rules: {
     strict: ['error', 'safe'],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

- import/extensions is defined in airbnb-config-base
- it is not related to react
- when a package is "type": "module", "mjs" should be present in the import extension.

### Solution

Move the rule in eslint-config

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
