### PR TITLE
fix(eslint-config-typescript): better typescript eslint config [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript-react/rules/react.js
+++ b/@ornikar/eslint-config-typescript-react/rules/react.js
@@ -13,8 +13,8 @@ module.exports = {
     'react/default-props-match-prop-types': 'off',
     'react/forbid-foreign-prop-types': 'off',
     'react/forbid-prop-types': 'off',
-    'react/no-unused-prop-types': 'off',
     'react/prop-types': 'off',
+    // https://github.com/yannickcr/eslint-plugin-react/issues/2702
     'react/sort-prop-types': 'off',
   },
 };

--- a/@ornikar/eslint-config-typescript-react/tests/react.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/react.tsx
@@ -1,8 +1,12 @@
 import type { FC, ReactElement, ReactNode } from 'react';
 
 interface AppIntlProviderProps {
+  // eslint-disable-next-line react/no-unused-prop-types
+  onClick?: string;
   locale: string;
   children: ReactNode;
+  // eslint-disable-next-line react/no-unused-prop-types
+  unusedProp?: string;
 }
 
 function AppIntlProvider({ locale, children }: AppIntlProviderProps): ReactElement {

--- a/@ornikar/eslint-config-typescript-react/tests/react.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/react.tsx
@@ -1,7 +1,6 @@
 import type { FC, ReactElement, ReactNode } from 'react';
 
 interface AppIntlProviderProps {
-  // eslint-disable-next-line react/no-unused-prop-types
   onClick?: string;
   locale: string;
   children: ReactNode;
@@ -9,7 +8,7 @@ interface AppIntlProviderProps {
   unusedProp?: string;
 }
 
-function AppIntlProvider({ locale, children }: AppIntlProviderProps): ReactElement {
+function AppIntlProvider({ locale, children, onClick }: AppIntlProviderProps): ReactElement {
   // eslint-disable-next-line react/react-in-jsx-scope
   return <>{children}</>;
 }

--- a/@ornikar/eslint-config-typescript/rules/import.js
+++ b/@ornikar/eslint-config-typescript/rules/import.js
@@ -24,10 +24,11 @@ module.exports = {
       },
     ],
 
-    /* issues */
-
-    /* some exported type doesnt work. tsc check that anyway */
+    /* https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#eslint-plugin-import */
     'import/named': 'off',
+    'import/namespace': 'off',
+    'import/default': 'off',
+    'import/no-named-as-default-member': 'off',
 
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
     'import/prefer-default-export': 'off',

--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -1,13 +1,7 @@
 'use strict';
 
 module.exports = {
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-  extends: [
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-  ],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
 
   rules: {
     /* Enabled */


### PR DESCRIPTION
### Context

Improve typescript-eslint config

- disable recommended import rules
- remove config already in extends
- reenable `react/no-unused-prop-types` which works with interface props definition