### PR TITLE
feat: add rules for eslint meeting ARCH-1376

### DIFF
--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -12,6 +12,16 @@ module.exports = {
   rules: {
     /* added rules */
 
+    // Code style following our guidelines: https://ornikar.atlassian.net/wiki/spaces/TECH/pages/855016043/Guide+Typescript#Cr%C3%A9ation-d%E2%80%99un-composant
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md
+    'react/function-component-definition': [
+      'error',
+      {
+        namedComponents: 'function-declaration',
+        unnamedComponents: 'function-expression',
+      },
+    ],
+
     // Prevent direct mutation of this.state
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
     'react/no-direct-mutation-state': 'error',

--- a/@ornikar/eslint-config-react/tests/Typography.js
+++ b/@ornikar/eslint-config-react/tests/Typography.js
@@ -20,6 +20,7 @@ Typography.div.propTypes = {
   children: PropTypes.node,
 };
 
+// eslint-disable-next-line react/function-component-definition
 const InvalidFunctionComponent = () => null;
 
 export function ComponentUsingTypographyDiv() {

--- a/@ornikar/eslint-config-typescript-react/tests/react.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/react.tsx
@@ -14,6 +14,7 @@ function AppIntlProvider({ locale, children, onClick }: AppIntlProviderProps): R
 }
 
 export const renderWithIntl = (ui: ReactElement, locale = 'fr-FR'): FC => {
+  // eslint-disable-next-line react/function-component-definition
   const IntlProvider: FC = ({ children }): ReactElement => {
     // eslint-disable-next-line react/react-in-jsx-scope
     return <AppIntlProvider locale={locale}>{children}</AppIntlProvider>;

--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -13,6 +13,9 @@ module.exports = {
     '@typescript-eslint/prefer-readonly': 'error',
     '@typescript-eslint/prefer-optional-chain': 'error',
 
+    /* Enabled as 'warn' in recommended, changed to 'error' */
+    '@typescript-eslint/no-non-null-assertion': 'error',
+
     /* Changed */
     '@typescript-eslint/ban-types': [
       'error',

--- a/@ornikar/eslint-config-typescript/tests/no-non-null-assertion.ts
+++ b/@ornikar/eslint-config-typescript/tests/no-non-null-assertion.ts
@@ -1,0 +1,8 @@
+interface PossiblyUndefined {
+  value: string | undefined;
+}
+
+const a: PossiblyUndefined = { value: undefined };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-non-null-assertion
+const foo: string = a.value!;


### PR DESCRIPTION
### Context

https://github.com/ornikar/eslint-configs/discussions/23

https://github.com/ornikar/eslint-configs/discussions/28  

### Solution

- Update `typescript-eslint.js` to add rule `@typescript-eslint/no-non-null-assertion` with `error` setting, to a new commented category called “'warn' to ‘error’”
- Update `eslint-configs/@ornikar/eslint-config-react/rules/react.js` to add `react/function-component-definition` rule with proposed code in repository rule discussion

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
