### PR TITLE
fix(eslint-config-typescript-react): fix import of react-native config [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/react-native.js
+++ b/@ornikar/eslint-config-react/react-native.js
@@ -1,26 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: ['.'].map(require.resolve),
-
-  env: {
-    browser: true,
-  },
-
-  globals: {
-    __DEV__: true,
-  },
-
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.js', '.ios.js', '.android.js'],
-      },
-    },
-  },
-
-  rules: {
-    'react/prefer-stateless-function': 'off',
-    'react/no-unescaped-entities': 'off',
-  },
+  extends: ['.', './rules/react-native'].map(require.resolve),
 };

--- a/@ornikar/eslint-config-react/rules/react-native.js
+++ b/@ornikar/eslint-config-react/rules/react-native.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  env: {
+    browser: true,
+  },
+
+  globals: {
+    __DEV__: true,
+  },
+
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.ios.js', '.android.js'],
+      },
+    },
+  },
+
+  rules: {
+    'react/prefer-stateless-function': 'off',
+    'react/no-unescaped-entities': 'off',
+  },
+};

--- a/@ornikar/eslint-config-typescript-react/react-native.js
+++ b/@ornikar/eslint-config-typescript-react/react-native.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  extends: ['.', '@ornikar/eslint-config-react/react-native'].map(require.resolve),
+  extends: ['.', '@ornikar/eslint-config-react/rules/react-native'].map(require.resolve),
 
   settings: {
     'import/resolver': {

--- a/@ornikar/eslint-config-typescript-react/tests/react-native/.eslintrc.json
+++ b/@ornikar/eslint-config-typescript-react/tests/react-native/.eslintrc.json
@@ -1,8 +1,11 @@
 {
   "root": true,
-  "extends": ["../index.js"],
+  "extends": ["../../react-native.js"],
   "parserOptions": {
     "project": "./@ornikar/eslint-config-typescript/tests/tsconfig.json",
     "createDefaultProgram": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": "off"
   }
 }

--- a/@ornikar/eslint-config-typescript-react/tests/react-native/MyComponent.ios.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/react-native/MyComponent.ios.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import type { ReactElement } from 'react';
+
+export function MyComponent(): ReactElement {
+  return <></>;
+}

--- a/@ornikar/eslint-config-typescript-react/tests/react-native/index.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/react-native/index.tsx
@@ -1,0 +1,6 @@
+import React, { ReactElement } from 'react';
+import MyComponent from './MyComponent';
+
+export function App(): ReactElement {
+  return <MyComponent />;
+}


### PR DESCRIPTION
### Context

Currently trying to import @ornikar/eslint-config-typescript-react/react-native imports @ornikar/eslint-config-babel

### Solution

Split react-native config and import only rules in eslint-config-typescript-react