### PR TITLE
chore: config renovate to open prs automaticly [no issue]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,13 @@
 {
-  "extends": ["config:js-lib", "@ornikar"]
+  "extends": ["config:js-lib", "@ornikar"],
+  "packageRules": [
+    {
+      "packagePatterns": ["^@typescript-eslint/", "^eslint-"],
+      "packageNames": ["eslint", "typescript"],
+      "updateTypes": ["patch", "minor"],
+      "labels": [":soon: automerge"],
+      "schedule": ["at any time"],
+      "reviewers": ["team:frontend-architects"]
+    }
+  ]
 }


### PR DESCRIPTION
### Context

We are not notified today about minor updates of eslint plugins. There are not either in the renovate dashboard issue.
This config should open the pr automaticly and notify us. We can then add the new rules in the discussions tab and merge the pr.