### PR TITLE
feat(eslint-config-typescript-react): allow unsafe prefix camelcase rule [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript-react/rules/react.js
+++ b/@ornikar/eslint-config-typescript-react/rules/react.js
@@ -16,5 +16,8 @@ module.exports = {
     'react/prop-types': 'off',
     // https://github.com/yannickcr/eslint-plugin-react/issues/2702
     'react/sort-prop-types': 'off',
+
+    // overrides camelcase rule to allow UNSAFE_* commonly used in react libraries
+    camelcase: ['error', { allow: ['^UNSAFE_'] }],
   },
 };

--- a/@ornikar/eslint-config-typescript-react/tests/case.tsx
+++ b/@ornikar/eslint-config-typescript-react/tests/case.tsx
@@ -1,0 +1,8 @@
+// eslint-disable-next-line camelcase
+const invalid_camelcase = 1;
+
+const UNSAFE_method = (value: number): number => {
+  return value;
+};
+
+UNSAFE_method(invalid_camelcase);


### PR DESCRIPTION
### Context

With react we often find UNSAFE methods.

As this is already very visible, we don't need to add an eslint-disable-next-line comment

Example: https://github.com/ornikar/instructors-app/pull/900#discussion_r734316259