### PR TITLE
fix: disable unicorn/prefer-at for node [no issue]

### DIFF
--- a/@ornikar/eslint-config/rules/node-override.js
+++ b/@ornikar/eslint-config/rules/node-override.js
@@ -25,5 +25,8 @@ module.exports = {
         .slice(1)
         .filter(({ selector }) => selector !== 'ForOfStatement'),
     ],
+
+    // TODO [engine:node@>=16.6] .at only supported from node 16.6
+    'unicorn/prefer-at': 'error',
   },
 };


### PR DESCRIPTION
Added by christopher, but we should not use it in node for now
