### PR TITLE
fix(eslint-config): really disable unicorn/prefer-at for node [no issue]

### DIFF
--- a/@ornikar/eslint-config/rules/node-override.js
+++ b/@ornikar/eslint-config/rules/node-override.js
@@ -27,6 +27,6 @@ module.exports = {
     ],
 
     // TODO [engine:node@>=16.6] .at only supported from node 16.6
-    'unicorn/prefer-at': 'error',
+    'unicorn/prefer-at': 'off',
   },
 };


### PR DESCRIPTION
see https://github.com/ornikar/eslint-configs/pull/182

I wrongly set it to 'error' not 'off'