### PR TITLE
fix(eslint-config-typescript): no unsafe argument as warn [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -63,6 +63,10 @@ module.exports = {
       },
     ],
 
+    /* Warning */
+
+    '@typescript-eslint/no-unsafe-argument': 'warn',
+
     /* Disabled */
 
     // interface can be used for empty props


### PR DESCRIPTION
### Context

This rule was wrongly enabled in https://github.com/ornikar/eslint-configs/pull/159

### Solution

Move it to 'warn' so that its still shows warning but doesn't need fixing right now