### PR TITLE
fix(eslint-config-react): stop overriding react/sort-comp [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -49,56 +49,6 @@ module.exports = {
 
     /* changed rules */
 
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
-    'react/sort-comp': [
-      'error',
-      {
-        order: [
-          'static-variables',
-          'static-methods',
-          'instance-variables',
-          'lifecycle',
-          'getters',
-          'setters',
-          '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
-          'instance-methods',
-          '/^(on|handle).+$/',
-          'everything-else',
-          'rendering',
-        ],
-        groups: {
-          lifecycle: [
-            'displayName',
-            'propTypes',
-            'contextTypes',
-            'childContextTypes',
-            'mixins',
-            'statics',
-            'defaultProps',
-            'constructor',
-            'getDefaultProps',
-            'getInitialState',
-            'state',
-            'getChildContext',
-            'getDerivedStateFromProps',
-            'componentWillMount',
-            'UNSAFE_componentWillMount',
-            'componentDidMount',
-            'componentWillReceiveProps',
-            'UNSAFE_componentWillReceiveProps',
-            'shouldComponentUpdate',
-            'componentWillUpdate',
-            'UNSAFE_componentWillUpdate',
-            'getSnapshotBeforeUpdate',
-            'componentDidUpdate',
-            'componentDidCatch',
-            'componentWillUnmount',
-          ],
-          rendering: ['/^render.+$/', 'render'],
-        },
-      },
-    ],
-
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md
     'react/forbid-dom-props': [
       'error',

--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -49,7 +49,7 @@ module.exports = {
 
     /* changed rules */
 
-    // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/sort-comp.md
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
     'react/sort-comp': [
       'error',
       {
@@ -60,6 +60,7 @@ module.exports = {
           'lifecycle',
           'getters',
           'setters',
+          '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
           'instance-methods',
           '/^(on|handle).+$/',
           'everything-else',
@@ -67,8 +68,18 @@ module.exports = {
         ],
         groups: {
           lifecycle: [
-            'state',
+            'displayName',
+            'propTypes',
+            'contextTypes',
+            'childContextTypes',
+            'mixins',
+            'statics',
+            'defaultProps',
             'constructor',
+            'getDefaultProps',
+            'getInitialState',
+            'state',
+            'getChildContext',
             'getDerivedStateFromProps',
             'componentWillMount',
             'UNSAFE_componentWillMount',


### PR DESCRIPTION
Our override causes issues with latest typescript-eslint update
airbnb rules matches our override but also fixes things

https://app.circleci.com/pipelines/github/ornikar/kitt/3536/workflows/6f6c619f-e17e-429a-b71e-a8eb2e2c5c36/jobs/24378