### PR TITLE
feat(eslint-config-typescript): add prefixed boolean naming-convention [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -84,5 +84,29 @@ module.exports = {
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
+
+    /* Naming convention */
+    '@typescript-eslint/naming-convention': [
+      'warn',
+      // enforce that boolean are prefixed with an allowed verb
+      {
+        selector: 'variable',
+        types: ['boolean'],
+        format: ['PascalCase'],
+        prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+      },
+      {
+        selector: 'property',
+        types: ['boolean'],
+        format: ['PascalCase'],
+        prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+      },
+      {
+        selector: 'parameterProperty',
+        types: ['boolean'],
+        format: ['PascalCase'],
+        prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

As decided in front COP, we want to enforce prefix booleans variables with a eslint warning.

### Solution

Add a new `@typescript-eslint/naming-convention` rule to TS lint rules