### PR TITLE
feat: disable naming convention when eslint is not ran from vscode extension [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { enableIfVSCode } = require('@ornikar/eslint-config/utils');
+
 module.exports = {
   extends: ['plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
 
@@ -87,7 +89,7 @@ module.exports = {
 
     /* Naming convention */
     '@typescript-eslint/naming-convention': [
-      'warn',
+      enableIfVSCode('warn'),
       // enforce that boolean are prefixed with an allowed verb
       {
         selector: 'variable',

--- a/@ornikar/eslint-config/utils.js
+++ b/@ornikar/eslint-config/utils.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const isVSCode = process.argv && process.argv.some((argv) => argv.includes('dbaeumer.vscode-eslint'));
+
+exports.enableIfVSCode = (ruleLevel) => (isVSCode ? ruleLevel : 'off');


### PR DESCRIPTION
This rule is one of the slowest one, and give us no value either in cli or in CI. It only should help us in dev when we name things

TImings in learner-apps
<img width="384" alt="image" src="https://user-images.githubusercontent.com/302891/155158212-8dc099ce-9567-4d0a-a1ca-5056c8c3b6ff.png">
