### PR TITLE
feat(eslint-config-react): allow arrow functions in stories [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/stories-override.js
+++ b/@ornikar/eslint-config-react/stories-override.js
@@ -9,5 +9,14 @@ module.exports = {
         devDependencies: true,
       },
     ],
+
+    // Allow arrow functions in stories
+    'react/function-component-definition': [
+      'error',
+      {
+        namedComponents: ['function-declaration', 'arrow-function'],
+        unnamedComponents: ['function-expression', 'arrow-function'],
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

Most of our warnings are in stories, most of them for decorators. We can allow without worry arrow functions for decorators, as they are not likely to change to functions with typescript generics.