### PR TITLE
feat(eslint-config-react): add testing-library/consistent-data-testid rule [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -10,6 +10,7 @@ const forbidDomAndComponentsProps = [
 
 module.exports = {
   extends: ['plugin:react/jsx-runtime'],
+  plugins: ['testing-library'],
 
   rules: {
     /* added rules */
@@ -100,5 +101,15 @@ module.exports = {
 
     // allow react-intl
     'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
+
+    // Allows consistent data-testid and testID
+    // Format is: sectionName.pageName?.FileName.uniqueIdentifier
+    'testing-library/consistent-data-testid': [
+      'warn',
+      {
+        testIdPattern: '^([a-z][a-zA-Z]+\\.)+{fileName}\\.([a-z][a-zA-Z]+)+$',
+        testIdAttribute: ['data-testid', 'testID'],
+      },
+    ],
   },
 };

--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -105,7 +105,7 @@ module.exports = {
     // Allows consistent data-testid and testID
     // Format is: sectionName.pageName?.FileName.uniqueIdentifier
     'testing-library/consistent-data-testid': [
-      'warn',
+      'error',
       {
         testIdPattern: '^([a-z][a-zA-Z]+\\.)+{fileName}\\.([a-z][a-zA-Z]+)+$',
         testIdAttribute: ['data-testid', 'testID'],

--- a/@ornikar/eslint-config-react/tests/ComponentWithTestId.js
+++ b/@ornikar/eslint-config-react/tests/ComponentWithTestId.js
@@ -9,5 +9,5 @@ ComponentWithTestId.propTypes = {
 };
 
 export function ComponentUsingComponentWithTestId() {
-  return <ComponentUsingComponentWithTestId data-testid="testid" />;
+  return <ComponentUsingComponentWithTestId data-testid="tests.ComponentWithTestId.unique" />;
 }

--- a/@ornikar/eslint-config-react/tests/ComponentWithTestId.js
+++ b/@ornikar/eslint-config-react/tests/ComponentWithTestId.js
@@ -9,5 +9,17 @@ ComponentWithTestId.propTypes = {
 };
 
 export function ComponentUsingComponentWithTestId() {
-  return <ComponentUsingComponentWithTestId data-testid="tests.ComponentWithTestId.unique" />;
+  return (
+    <>
+      {/* eslint-disable-next-line react/forbid-component-props */}
+      <ComponentUsingComponentWithTestId data-test="tests.ComponentWithTestId.unique" />
+      {/* eslint-disable-next-line react/forbid-component-props */}
+      <ComponentUsingComponentWithTestId data-test-id="tests.ComponentWithTestId.unique" />
+      {/* eslint-disable-next-line react/forbid-component-props */}
+      <ComponentUsingComponentWithTestId data-test-class="tests.ComponentWithTestId.unique" />
+
+      <ComponentUsingComponentWithTestId data-testid="tests.ComponentWithTestId.unique" />
+      <ComponentUsingComponentWithTestId testID="tests.ComponentWithTestId.unique" />
+    </>
+  );
 }

--- a/@ornikar/eslint-config-react/tests/consistent-data-testid.js
+++ b/@ornikar/eslint-config-react/tests/consistent-data-testid.js
@@ -1,0 +1,20 @@
+function View() {
+  return null;
+}
+
+export function App() {
+  return (
+    <>
+      {/* Incorrect code */}
+      <View testID="empty" />
+      <View testID="camelCase" />
+      <View testID="PascalCase" />
+      <View testID="sectionName.uniqueIdentifier" />
+      <View testID="sectionName.pageName.WrongFileName.uniqueIdentifier" />
+
+      {/* Correct code */}
+      <View testID="sectionName.consistent-data-testid.uniqueIdentifier" />
+      <View testID="sectionName.pageName.consistent-data-testid.uniqueIdentifier" />
+    </>
+  );
+}

--- a/@ornikar/eslint-config-react/tests/consistent-data-testid.js
+++ b/@ornikar/eslint-config-react/tests/consistent-data-testid.js
@@ -6,10 +6,15 @@ export function App() {
   return (
     <>
       {/* Incorrect code */}
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="empty" />
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="camelCase" />
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="PascalCase" />
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="sectionName.uniqueIdentifier" />
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="sectionName.pageName.WrongFileName.uniqueIdentifier" />
 
       {/* Correct code */}

--- a/@ornikar/eslint-config-react/tests/consistent-data-testid.js
+++ b/@ornikar/eslint-config-react/tests/consistent-data-testid.js
@@ -7,6 +7,8 @@ export function App() {
     <>
       {/* Incorrect code */}
       {/* eslint-disable-next-line testing-library/consistent-data-testid */}
+      <View data-testid="empty" />
+      {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="empty" />
       {/* eslint-disable-next-line testing-library/consistent-data-testid */}
       <View testID="camelCase" />
@@ -18,6 +20,7 @@ export function App() {
       <View testID="sectionName.pageName.WrongFileName.uniqueIdentifier" />
 
       {/* Correct code */}
+      <View data-testid="sectionName.consistent-data-testid.uniqueIdentifier" />
       <View testID="sectionName.consistent-data-testid.uniqueIdentifier" />
       <View testID="sectionName.pageName.consistent-data-testid.uniqueIdentifier" />
     </>


### PR DESCRIPTION
### Context

Add [testing-library/consistent-data-testid](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/consistent-data-testid.md) rule.

### Solution

- Regex is following the rule from https://ornikar.atlassian.net/wiki/spaces/TECH/pages/3048375320/Testing+Library+draft#Name-your-test-IDs-properly
- Rule is in the shared config and not the tests-override as we don't want to see the error after writing the testId. It allows us to check the testId for e2e tests too
- It's a warning for now, the naming convention could change now that we'll use it and there are a LOT of test id in certain codebases

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
