### PR TITLE
feat(eslint-config-typescript): restrict act imports [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/tests-override.js
+++ b/@ornikar/eslint-config-typescript/tests-override.js
@@ -2,4 +2,19 @@
 
 module.exports = {
   extends: ['@ornikar/eslint-config/tests-override'].map(require.resolve),
+
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'react-test-renderer',
+            importNames: ['act'],
+            message: 'Please use act from @testing-library/* instead.',
+          },
+        ],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
### Context

Restrict act imports to `@testing-library/*`.

### Solution

- Only in `tests-override`

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
