### PR TITLE
feat(eslint-config-react): disable consistent-data-testid on tests [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/tests-override.js
+++ b/@ornikar/eslint-config-react/tests-override.js
@@ -2,4 +2,9 @@
 
 module.exports = {
   extends: ['@ornikar/eslint-config/tests-override', './rules/react-testing-library'].map(require.resolve),
+  plugins: ['testing-library'],
+
+  rules: {
+    'testing-library/consistent-data-testid': 'off',
+  },
 };

--- a/@ornikar/eslint-config-react/tests/react-testing-library/consistent-data-testid.js
+++ b/@ornikar/eslint-config-react/tests/react-testing-library/consistent-data-testid.js
@@ -2,7 +2,8 @@ function View() {
   return null;
 }
 
-// Rules is disable for tests, see below for the real tests
+// Rule is disabled for tests, see below for the real tests
+// @ornikar/eslint-config-react/tests/consistent-data-testid.js
 export function App() {
   return <View data-testid="unruledTestId" />;
 }

--- a/@ornikar/eslint-config-react/tests/react-testing-library/consistent-data-testid.js
+++ b/@ornikar/eslint-config-react/tests/react-testing-library/consistent-data-testid.js
@@ -1,0 +1,8 @@
+function View() {
+  return null;
+}
+
+// Rules is disable for tests, see below for the real tests
+export function App() {
+  return <View data-testid="unruledTestId" />;
+}


### PR DESCRIPTION
### Context

Disable `testing-library/consistent-data-test-id` for tests. This enables direct usage of test-id in tests file (see [react-forms-universal example](https://github.com/ornikar/components/blob/82fe8a0b020cad0a5fa721982f83a13271c1730c/@ornikar/react-forms-universal/src/Field/index.native.test.tsx))

### Solution

- Disable the rule in `tests-override`

### Testing plan
- [x] Test to show it is disabled in tests 🥴 
