### PR TITLE
feat(eslint-config): add forbid-component-props for data-testid INS-1880

### DIFF
--- a/@ornikar/eslint-config-react/rules/react-native.js
+++ b/@ornikar/eslint-config-react/rules/react-native.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const forbidComponentsProps = [{ propName: 'data-testid', message: 'Use testID for native components' }];
+
 module.exports = {
   env: {
     browser: true,
@@ -20,5 +22,12 @@ module.exports = {
   rules: {
     'react/prefer-stateless-function': 'off',
     'react/no-unescaped-entities': 'off',
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md
+    'react/forbid-component-props': [
+      'error',
+      {
+        forbid: forbidComponentsProps,
+      },
+    ],
   },
 };

--- a/@ornikar/eslint-config-react/tests/react-native/.eslintrc.json
+++ b/@ornikar/eslint-config-react/tests/react-native/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["../../react-native.js"]
+}

--- a/@ornikar/eslint-config-react/tests/react-native/forbid-component-props.js
+++ b/@ornikar/eslint-config-react/tests/react-native/forbid-component-props.js
@@ -1,0 +1,17 @@
+function View() {
+  return null;
+}
+
+export function App() {
+  return (
+    <>
+      {/* Incorrect code */}
+      {/* eslint-disable-next-line react/forbid-component-props */}
+      <View data-testid="sectionName.forbid-component-props.uniqueIdentifier" />
+
+      {/* Correct code */}
+      <div data-testid="sectionName.forbid-component-props.uniqueIdentifier" />
+      <View testID="sectionName.forbid-component-props.uniqueIdentifier" />
+    </>
+  );
+}


### PR DESCRIPTION
### Context

To handle test ids on both web and native apps we need to pass the testID prop to kitt-universal components.

For web components the prop used is data-testid and for native components it’s testID

Passing the testID prop to a component handled by react-native-web (View, Text, TextInput) will convert it to data-testid when rendering the DOM.

Passing the data-testid prop to a component won't used when rendering the DOM.


Jira : [INS-1880](https://ornikar.atlassian.net/browse/INS-1880)

### Solution

`data-testid` will be forbidden on React Native components, but still useable on dom elements
