### PR TITLE
feat: remove prefer-stateless-function from react-native INS-1926

### DIFF
--- a/@ornikar/eslint-config-react/rules/react-native.js
+++ b/@ornikar/eslint-config-react/rules/react-native.js
@@ -20,7 +20,6 @@ module.exports = {
   },
 
   rules: {
-    'react/prefer-stateless-function': 'off',
     'react/no-unescaped-entities': 'off',
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md
     'react/forbid-component-props': [


### PR DESCRIPTION
### Context

Eslint Meeting : [2022-09-06](https://ornikar.atlassian.net/wiki/spaces/TECH/pages/3406007453/2022-09-06)
Jira : [INS-1926](https://ornikar.atlassian.net/browse/INS-1926)
The rule ‘react/prefer-stateless-function' was deactivated for react native for a long time when stateless function were introduced and didn’t work with react native, now that react native supports them we want to reactivate the rule.

### Tests

Added the rule and ran linter on selfcare, instructor and learner without issue
