### PR TITLE
fix: fix react-testing-library override for typescript-react [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/_shared.js
+++ b/@ornikar/eslint-config-react/_shared.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  extends: ['./rules/react', './rules/security'].map(require.resolve),
+  extends: ['./rules/react', './rules/react-testing-library-base', './rules/security'].map(require.resolve),
 
   settings: {
     'import/resolver': {

--- a/@ornikar/eslint-config-react/rules/react-testing-library-base.js
+++ b/@ornikar/eslint-config-react/rules/react-testing-library-base.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  plugins: ['testing-library'],
+  rules: {
+    // Allows consistent data-testid and testID
+    // Format is: sectionName.pageName?.FileName.uniqueIdentifier
+    'testing-library/consistent-data-testid': [
+      'error',
+      {
+        testIdPattern: '^([a-z][a-zA-Z]+\\.)+{fileName}\\.([a-z][a-zA-Z]+)+$',
+        testIdAttribute: ['data-testid', 'testID'],
+      },
+    ],
+  },
+};

--- a/@ornikar/eslint-config-react/rules/react-testing-library-tests.js
+++ b/@ornikar/eslint-config-react/rules/react-testing-library-tests.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-  plugins: ['testing-library'],
   rules: {
+    'testing-library/consistent-data-testid': 'off',
     'testing-library/await-async-query': 'error',
     'testing-library/await-async-utils': 'error',
     'testing-library/no-await-sync-events': 'error',

--- a/@ornikar/eslint-config-react/rules/react.js
+++ b/@ornikar/eslint-config-react/rules/react.js
@@ -10,7 +10,6 @@ const forbidDomAndComponentsProps = [
 
 module.exports = {
   extends: ['plugin:react/jsx-runtime'],
-  plugins: ['testing-library'],
 
   rules: {
     /* added rules */
@@ -116,15 +115,5 @@ module.exports = {
 
     // allow react-intl
     'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
-
-    // Allows consistent data-testid and testID
-    // Format is: sectionName.pageName?.FileName.uniqueIdentifier
-    'testing-library/consistent-data-testid': [
-      'error',
-      {
-        testIdPattern: '^([a-z][a-zA-Z]+\\.)+{fileName}\\.([a-z][a-zA-Z]+)+$',
-        testIdAttribute: ['data-testid', 'testID'],
-      },
-    ],
   },
 };

--- a/@ornikar/eslint-config-react/tests-override.js
+++ b/@ornikar/eslint-config-react/tests-override.js
@@ -1,10 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: ['@ornikar/eslint-config/tests-override', './rules/react-testing-library'].map(require.resolve),
-  plugins: ['testing-library'],
-
-  rules: {
-    'testing-library/consistent-data-testid': 'off',
-  },
+  extends: ['@ornikar/eslint-config/tests-override', './rules/react-testing-library-tests'].map(require.resolve),
 };

--- a/@ornikar/eslint-config-typescript-react/_shared.js
+++ b/@ornikar/eslint-config-typescript-react/_shared.js
@@ -3,6 +3,7 @@
 module.exports = {
   extends: [
     '@ornikar/eslint-config-react/rules/react',
+    '@ornikar/eslint-config-react/rules/react-testing-library-base',
     '@ornikar/eslint-config-react/rules/security',
     // overrides for react with typescript (mostly extensions)
     './rules/import',

--- a/@ornikar/eslint-config-typescript-react/tests-override.js
+++ b/@ornikar/eslint-config-typescript-react/tests-override.js
@@ -3,6 +3,6 @@
 module.exports = {
   extends: [
     '@ornikar/eslint-config-typescript/tests-override',
-    '@ornikar/eslint-config-react/rules/react-testing-library',
+    '@ornikar/eslint-config-react/rules/react-testing-library-tests',
   ].map(require.resolve),
 };


### PR DESCRIPTION
### Context

Currently, with `eslint-config-typescript-react/tests-override`, `consistent-data-testid` is not off because it is only off on non-typescript projects

Instead of duplicating the `off`, I splitted testing-library configs in eslint-config-react for base (source files) and tests (override).
Also, the `react` config is no longer linked to the plugin `testing-library` which makes more sense as the config is currently splitted by plugins.