### PR TITLE
feat(eslint-config-react): allow default export in stories for CSF [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/stories-override.js
+++ b/@ornikar/eslint-config-react/stories-override.js
@@ -10,6 +10,9 @@ module.exports = {
       },
     ],
 
+    // Allow default export for CSF
+    'import/no-default-export': 'off',
+
     // Allow arrow functions in stories
     'react/function-component-definition': [
       'error',

--- a/@ornikar/eslint-config-react/tests/stories/.eslintrc.json
+++ b/@ornikar/eslint-config-react/tests/stories/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["../../", "../../stories-override.js"]
+}

--- a/@ornikar/eslint-config-react/tests/stories/Avatar.stories.js
+++ b/@ornikar/eslint-config-react/tests/stories/Avatar.stories.js
@@ -1,0 +1,10 @@
+function Avatar() {
+  return null;
+}
+
+export default {
+  title: 'kitt-universal/Data Display/Avatar',
+  component: Avatar,
+};
+
+export const AvatarStory = () => <Avatar />;


### PR DESCRIPTION
Allow to use CSF format with `export default` as shown in test example