### PR TITLE
feat: disable node/shebang for our js scripts [no issue]

### DIFF
--- a/@ornikar/eslint-config/rules/node.js
+++ b/@ornikar/eslint-config/rules/node.js
@@ -28,5 +28,11 @@ module.exports = {
         ecmaVersion: 2022,
       },
     },
+    {
+      files: ['scripts/**'],
+      rules: {
+        'n/shebang': 'off',
+      },
+    },
   ],
 };


### PR DESCRIPTION
[node/shebang](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/shebang.md) rule is enabled by default.

> This rule checks bin field of package.json, then if a target file matches one of bin files, it checks whether or not there is a correct shebang. Otherwise it checks whether or not there is not a shebang.

This automatically remove `#!/usr/bin/env node` inside our scripts, but we want them.

➡️ This PR disable `node/shebang` for our script (files inside `/scripts` folder)