### PR TITLE
fix: configure imports for base config [no issue]

### DIFF
--- a/@ornikar/eslint-config/_shared.js
+++ b/@ornikar/eslint-config/_shared.js
@@ -3,6 +3,7 @@
 module.exports = {
   extends: [
     './rules/best-practices',
+    './rules/imports',
     './rules/style',
     './rules/sort-imports-exports',
     './rules/security',

--- a/@ornikar/eslint-config/rules/imports.js
+++ b/@ornikar/eslint-config/rules/imports.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    /* https://ornikar.atlassian.net/wiki/spaces/TECH/pages/2670330094/Avoid+default+export */
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+    'import/prefer-default-export': 'off',
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-default-export.md
+    'import/no-default-export': 'error',
+  },
+};

--- a/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-fail-1.js
+++ b/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-fail-1.js
@@ -2,5 +2,5 @@
 
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import defaultExport from './foo';
-// eslint-disable-next-line unicorn/prefer-export-from
+// eslint-disable-next-line unicorn/prefer-export-from, import/no-default-export
 export default defaultExport;

--- a/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-fail-2.js
+++ b/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-fail-2.js
@@ -2,5 +2,5 @@
 
 // eslint-disable-next-line no-unused-vars, import/no-unresolved, import/extensions
 import defaultExport, { named } from './foo';
-// eslint-disable-next-line unicorn/prefer-export-from
+// eslint-disable-next-line unicorn/prefer-export-from, import/no-default-export
 export default defaultExport;

--- a/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-pass-1.js
+++ b/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-pass-1.js
@@ -1,4 +1,4 @@
 // Correct uses
 
-// eslint-disable-next-line import/no-unresolved, import/extensions, no-restricted-exports
-export { default } from './foo';
+// eslint-disable-next-line import/no-unresolved, import/extensions
+export { default as foo } from './foo';

--- a/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-pass-2.js
+++ b/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from-pass-2.js
@@ -1,4 +1,4 @@
 // Correct uses
 
-// eslint-disable-next-line import/no-unresolved, import/extensions, no-restricted-exports
+// eslint-disable-next-line import/no-unresolved, import/extensions, no-restricted-exports, import/no-default-export
 export { default, named, default as renamedDefault, named as renamedNamed } from './foo';

--- a/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from.js
+++ b/@ornikar/eslint-config/tests/node-module/prefer-export-from/prefer-export-from.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-unresolved, import/extensions, import/order, import/first, simple-import-sort/exports, import/newline-after-import, import/no-duplicates */
+/* eslint-disable import/no-unresolved, import/extensions, import/order, import/first, simple-import-sort/exports, import/no-duplicates */
 
 // Incorrect uses
 
@@ -14,12 +14,11 @@ import defaultExport, { namedBar } from './foo';
 // eslint-disable-next-line unicorn/prefer-export-from
 export { namedBar, defaultExport as renamedDefault, namedBar as renamedNamed };
 
+// eslint-disable-next-line import/no-default-export
+export default namespaceFoo;
+
 // Correct uses
 
-import * as namespaceBaz from './foo';
 export { namedBaz } from './foo';
 
 export * as namespaceBar from './foo.js';
-
-// There is no substitution
-export default namespaceBaz;


### PR DESCRIPTION
### Context

Now that we use imports in mjs files, we have to configure eslint-config too.