### PR TITLE
feat(eslint-plugin-ornikar): create sentry-capture-always-capturedIn plugin [no issue]

### DIFF
--- a/@ornikar/eslint-plugin-ornikar/rules/sentry-capture-always-capturedIn.js
+++ b/@ornikar/eslint-plugin-ornikar/rules/sentry-capture-always-capturedIn.js
@@ -1,0 +1,91 @@
+'use strict';
+
+exports.meta = {
+  type: 'problem',
+
+  docs: {
+    description: 'Force sentry captureMessage and captureException to have extra.capturedIn property',
+    category: 'Best Practices',
+    recommended: true,
+  },
+
+  messages: {
+    noExtraCapturedInProperty: 'Add extra.capturedIn property',
+  },
+};
+
+const calleeNames = ['captureException', 'captureMessage'];
+const sentryRNImportName = '@sentry/react-native';
+
+exports.create = ({ report, sourceCode }) => {
+  const searchForPropertyName = (objectExpressionNode, propertyName) => {
+    let objectExpression;
+    objectExpressionNode.properties.forEach((property) => {
+      if (property.key.type === 'Identifier' && property.key.name === propertyName) {
+        objectExpression = property.value;
+      }
+    });
+    return objectExpression;
+  };
+
+  const checkCallExpressionArguments = (callExpressionArguments) => {
+    const secondArgs = callExpressionArguments.arguments[1];
+    if (!secondArgs) {
+      report({ node: callExpressionArguments, messageId: 'noExtraCapturedInProperty' });
+      return;
+    }
+
+    if (secondArgs.type === 'ObjectExpression') {
+      const extraObjectExpression = searchForPropertyName(secondArgs, 'extra');
+
+      if (!extraObjectExpression || extraObjectExpression.type !== 'ObjectExpression') {
+        report({ node: callExpressionArguments, messageId: 'noExtraCapturedInProperty' });
+      }
+
+      const extraCapturedInObjectExpression = searchForPropertyName(extraObjectExpression, 'capturedIn');
+
+      if (!extraCapturedInObjectExpression) {
+        report({ node: callExpressionArguments, messageId: 'noExtraCapturedInProperty' });
+      }
+    }
+  };
+
+  return {
+    ImportDeclaration: (node) => {
+      if (node.source.type === 'Literal' && node.source.value === sentryRNImportName) {
+        node.specifiers.forEach((specifier) => {
+          if (specifier.type === 'ImportNamespaceSpecifier' && specifier.local.type === 'Identifier') {
+            sourceCode.getScope(specifier).references.forEach((reference) => {
+              if (
+                reference.identifier.type === 'Identifier' &&
+                reference.identifier.parent.type === 'MemberExpression'
+              ) {
+                const memberExpression = reference.identifier.parent;
+
+                if (memberExpression.parent.type === 'CallExpression') {
+                  checkCallExpressionArguments(memberExpression.parent);
+                }
+              }
+            });
+          }
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.local.type === 'Identifier' &&
+            calleeNames.includes(specifier.local.name)
+          ) {
+            const methodName = specifier.local.name;
+            sourceCode.getScope(specifier).references.forEach((reference) => {
+              if (
+                reference.identifier.type === 'Identifier' &&
+                reference.identifier.parent.type === 'CallExpression' &&
+                reference.identifier.name === methodName
+              ) {
+                checkCallExpressionArguments(reference.identifier.parent);
+              }
+            });
+          }
+        });
+      }
+    },
+  };
+};

--- a/@ornikar/eslint-plugin-ornikar/rules/sentry-capture-always-capturedIn.test.js
+++ b/@ornikar/eslint-plugin-ornikar/rules/sentry-capture-always-capturedIn.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('./sentry-capture-always-capturedIn');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('sentry-capture-always-capturedIn', rule, {
+  valid: [
+    {
+      code: "captureMessage('test', { extra: { capturedIn: 'path' } });",
+    },
+    {
+      code: "captureException('test', { extra: { capturedIn: 'path' } });",
+    },
+    {
+      code: `
+        import { captureMessage } from '@sentry/react-native'
+        captureException('test', { extra: { capturedIn: 'path' } });
+      `,
+    },
+    {
+      code: `
+        import * as Blob from '@sentry/react-native'
+        Blob.captureException('test', { extra: { capturedIn: 'path' } });
+      `,
+    },
+    {
+      code: `
+        import * as Blob from 'test'
+        Blob.captureException('test', { extra: { test: 1 } });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import * as Sentry from '@sentry/react-native'
+        Sentry.captureException('test', { extra: { test: 1 } });
+      `,
+      errors: [
+        {
+          messageId: 'noExtraCapturedInProperty',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as Plouf from '@sentry/react-native'
+        Plouf.captureException('test');
+      `,
+      errors: [
+        {
+          messageId: 'noExtraCapturedInProperty',
+        },
+      ],
+    },
+    {
+      code: `
+        import { captureMessage } from '@sentry/react-native'
+        captureMessage('test', { extra: { test: 1 } });
+      `,
+      errors: [
+        {
+          messageId: 'noExtraCapturedInProperty',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
### Context

Création d'une règle eslint permettant d'obliger l'ajout de la prop `extra.capturedIn` en paramètre des méthodes `captureMessage` et `captureException` de Sentry.

Permet de respecter la guideline: https://ornikar.atlassian.net/wiki/spaces/TECH/pages/1332019349/How+to+use+Sentry
