### PR TITLE
feat(eslint-config-typescript): add @typescript-eslint/no-unnecessary-boolean-literal-compare [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/rules/typescript-eslint.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/no-invalid-void-type': 'error',
     '@typescript-eslint/prefer-reduce-type-parameter': 'error',
     '@typescript-eslint/no-duplicate-type-constituents': 'error',
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
 
     /* Enabled as 'warn' in recommended, changed to 'error' */
     '@typescript-eslint/no-non-null-assertion': 'error',

--- a/@ornikar/eslint-config-typescript/tests/no-unnecessary-boolean-literal-compare.ts
+++ b/@ornikar/eslint-config-typescript/tests/no-unnecessary-boolean-literal-compare.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-empty */
+/* Incorrect */
+
+declare const someCondition: boolean;
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+if (someCondition === true) {
+}
+
+/* Correct */
+
+declare const someCondition2: boolean;
+if (someCondition2) {
+}
+
+declare const someObjectBoolean: boolean | Record<string, unknown>;
+if (someObjectBoolean === true) {
+}
+
+declare const someStringBoolean: boolean | string;
+if (someStringBoolean === true) {
+}


### PR DESCRIPTION
### Context

Implements https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare, see https://github.com/ornikar/eslint-configs/discussions/645.