### PR TITLE
feat(eslint-config-typescript): add no restricted imports rule OSE-8660

### DIFF
--- a/@ornikar/eslint-config-typescript/rules/import.js
+++ b/@ornikar/eslint-config-typescript/rules/import.js
@@ -35,5 +35,27 @@ module.exports = {
 
     /* Avoid default exports: https://ornikar.atlassian.net/wiki/spaces/TECH/pages/2670330094/Avoid+default+export */
     'import/no-default-export': 'error',
+
+    'no-restricted-imports': [
+      'warn',
+      {
+        paths: [
+          {
+            name: '@apollo/client/react/components',
+            message: 'Use hooks instead of legacy components.',
+          },
+          {
+            name: '@apollo/client',
+            importNames: ['useQuery', 'useMutation'],
+            message: 'Use @ornikar/react-apollo hooks instead.',
+          },
+          {
+            name: 'react-final-form',
+            importNames: ['Form'],
+            message: 'Use @ornikar/react-forms-universal instead.',
+          },
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

Afin d'uniformiser nos configs eslint sur nos repos, nous souhaitons supprimer les overrides de règles et s'appuyer sur notre config partagée. Cette PR a pour objectif de partager la règle @typescript-eslint/no-restricted-imports pour tous les projets

https://ornikar.atlassian.net/browse/OSE-8660

### Solution
Reporter la règle présente dans [instructor-apps
](https://github.com/ornikar/instructors-app/blob/master/%40ornikar/instructor-native-app/src/.eslintrc.json#L46)

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
