### PR TITLE
fix: add libc to supportedArchitectures for Yarn 4 compatibility [no issue]

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -19,5 +19,7 @@ supportedArchitectures:
   os:
     - linux
     - darwin
+  libc:
+    - glibc
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs


### PR DESCRIPTION
## Summary

- Adds `libc: [glibc]` to `supportedArchitectures` in `.yarnrc.yml`
- Yarn 4 changed the default behavior of `supportedArchitectures.libc` to only include the current system's libc. On macOS, this means glibc bindings are not cached for Linux targets, causing CI failures for packages with native bindings (e.g. `@unrs/resolver-binding-*`).
- This fix explicitly declares `glibc` so that Linux-targeted native bindings are always resolved and cached, regardless of the developer's local OS.

## Test plan

- [x] `yarn install` runs successfully with the updated config
- [x] All existing tests pass
- [x] Verify CI pipeline succeeds with the new `supportedArchitectures` configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)